### PR TITLE
fix typo in comment - transition.js

### DIFF
--- a/src/transition.js
+++ b/src/transition.js
@@ -9,8 +9,8 @@ var transition = { // module containing transition helper functions
   },
 
   color_interp: function color_interp(t) {
-    var color1 = this.startValue ; // here, "this" revers to whatever context this gets bound to (not this module itself)
-    var color2 = this.endValue ;   // here, "this" revers to whatever context this gets bound to (not this module itself)
+    var color1 = this.startValue ; // here, "this" refers to whatever context this gets bound to (not this module itself)
+    var color2 = this.endValue ;   // here, "this" refers to whatever context this gets bound to (not this module itself)
 
     color1 = color1.slice(1) ; // take off the hash
     color2 = color2.slice(1) ; // take off the hash


### PR DESCRIPTION
Fixed a type.  Github adds the newline at the end of the file when you use their site to make a commit, so they're responsible for that change.
